### PR TITLE
adds reuqests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.1.2
 gunicorn==20.0.4
-
+requests==2.23.0


### PR DESCRIPTION
All you needed was a line requiring requests - since you used an API, your hosting service needs to know to also install the library you used to access the API.